### PR TITLE
Fixing typos

### DIFF
--- a/docs/source/examples/1D-Lookup-DEMO.rst
+++ b/docs/source/examples/1D-Lookup-DEMO.rst
@@ -17,7 +17,7 @@
     and provided merely to remove any validation errors that might otherwise occur.
         
     Note, in particular, that any conscientious reviewer would consider the data structure classes
-    to be inadequate without appropriate descriptions, extrema, null data indicates, and similar
+    to be inadequate without appropriate descriptions, extrema, null data indicators, and similar
     essential metadata.
 
     This label demonstrates:

--- a/docs/source/examples/1D-Uniformly-Sampled-DEMO.rst
+++ b/docs/source/examples/1D-Uniformly-Sampled-DEMO.rst
@@ -17,7 +17,7 @@
         and provided merely to remove any validation errors that might otherwise occur.
             
         Note, in particular, that any conscientious reviewer would consider the data structure classes
-        to be inadequate without appropriate descriptions, extrema, null data indicates, and similar
+        to be inadequate without appropriate descriptions, extrema, null data indicators, and similar
         essential metadata.
     
         This label demonstrates:

--- a/docs/source/examples/2D-Uniformly-Sampled-DEMO.rst
+++ b/docs/source/examples/2D-Uniformly-Sampled-DEMO.rst
@@ -17,7 +17,7 @@
         and provided merely to remove any validation errors that might otherwise occur.
             
         Note, in particular, that any conscientious reviewer would consider the data structure classes
-        to be inadequate without appropriate descriptions, extrema, null data indicates, and similar
+        to be inadequate without appropriate descriptions, extrema, null data indicators, and similar
         essential metadata.
     
         This label demonstrates:

--- a/docs/source/examples/3D-Axis-Bin-Set-DEMO.rst
+++ b/docs/source/examples/3D-Axis-Bin-Set-DEMO.rst
@@ -17,7 +17,7 @@
         and provided merely to remove any validation errors that might otherwise occur.
             
         Note, in particular, that any conscientious reviewer would consider the data structure classes
-        to be inadequate without appropriate descriptions, extrema, null data indicates, and similar
+        to be inadequate without appropriate descriptions, extrema, null data indicators, and similar
         essential metadata.
     
         This label demonstrates:

--- a/docs/source/examples/3D-Lookup-DEMO.rst
+++ b/docs/source/examples/3D-Lookup-DEMO.rst
@@ -17,7 +17,7 @@
         and provided merely to remove any validation errors that might otherwise occur.
             
         Note, in particular, that any conscientious reviewer would consider the data structure classes
-        to be inadequate without appropriate descriptions, extrema, null data indicates, and similar
+        to be inadequate without appropriate descriptions, extrema, null data indicators, and similar
         essential metadata.
     
         This label demonstrates:

--- a/docs/source/examples/Tabulated-Flat-External-Lookup-DEMO.rst
+++ b/docs/source/examples/Tabulated-Flat-External-Lookup-DEMO.rst
@@ -17,7 +17,7 @@ Tabulated-Flat Spectra, external Spectral Lookup, unknown bin widths
         and provided merely to remove any validation errors that might otherwise occur.
             
         Note, in particular, that any conscientious reviewer would consider the data structure classes
-        to be inadequate without appropriate descriptions, extrema, null data indicates, and similar
+        to be inadequate without appropriate descriptions, extrema, null data indicators, and similar
         essential metadata.
     
         This label demonstrates:

--- a/docs/source/examples/Tabulated-Flat-Local-Lookup-DEMO.rst
+++ b/docs/source/examples/Tabulated-Flat-Local-Lookup-DEMO.rst
@@ -17,7 +17,7 @@ Tabulated-Flat Spectrum, field number list
         and provided merely to remove any validation errors that might otherwise occur.
             
         Note, in particular, that any conscientious reviewer would consider the data structure classes
-        to be inadequate without appropriate descriptions, extrema, null data indicates, and similar
+        to be inadequate without appropriate descriptions, extrema, null data indicators, and similar
         essential metadata.
     
         This label demonstrates:

--- a/docs/source/examples/Tabulated-Param-Local-Lookup-DEMO.rst
+++ b/docs/source/examples/Tabulated-Param-Local-Lookup-DEMO.rst
@@ -17,7 +17,7 @@ Tabulated-Parameter Groups Spectrum, internal Spectral Lookup
         and provided merely to remove any validation errors that might otherwise occur.
             
         Note, in particular, that any conscientious reviewer would consider the data structure classes
-        to be inadequate without appropriate descriptions, extrema, null data indicates, and similar
+        to be inadequate without appropriate descriptions, extrema, null data indicators, and similar
         essential metadata.
     
         This label demonstrates:

--- a/docs/source/examples/Tabulated-Point-Local-Lookup-DEMO.rst
+++ b/docs/source/examples/Tabulated-Point-Local-Lookup-DEMO.rst
@@ -17,7 +17,7 @@ Tabulated-Point Group Spectrum, local Spectral Lookup
         and provided merely to remove any validation errors that might otherwise occur.
         
         Note, in particular, that any conscientious reviewer would consider the data structure classes
-        to be inadequate without appropriate descriptions, extrema, null data indicates, and similar
+        to be inadequate without appropriate descriptions, extrema, null data indicators, and similar
         essential metadata.
         
         This label demonstrates:

--- a/docs/source/examples/Tabulated-Point-Local-Width-Constant-DEMO.rst
+++ b/docs/source/examples/Tabulated-Point-Local-Width-Constant-DEMO.rst
@@ -17,7 +17,7 @@ Tabulated-Point Group Spectrum, constant bin width in Spectral Lookup
         and provided merely to remove any validation errors that might otherwise occur.
         
         Note, in particular, that any conscientious reviewer would consider the data structure classes
-        to be inadequate without appropriate descriptions, extrema, null data indicates, and similar
+        to be inadequate without appropriate descriptions, extrema, null data indicators, and similar
         essential metadata.
         
         This label demonstrates:


### PR DESCRIPTION
Fixing a repeated typo in the example labels discovered on reviewing the new posted example labels.
